### PR TITLE
Provisioning PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ gradle-app.setting
 .DS_Store
 scripts/.DS_Store
 src/.DS_Store
+
+out/

--- a/scripts/Unix/eclipselink-test-setup.sh
+++ b/scripts/Unix/eclipselink-test-setup.sh
@@ -1,0 +1,159 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#!/bin/bash
+githubAccount=ebenezergraham
+
+# REM create core folder
+mkdir -p core
+cd core
+
+get_modules() {
+  for module in $@
+  do
+    git clone https://github.com/apache/$module.git
+    cd $module
+    ./gradlew publishToMavenLocal
+    cd ..
+  done
+}
+
+get_modules_with_fincn_2() {
+  for module in $@
+  do
+    git clone -b FINCN-2 https://github.com/$githubAccount/$module.git
+    cd $module
+    ./gradlew publishToMavenLocal
+    cd ..
+  done
+}
+
+get_modules fineract-cn-lang fineract-cn-api fineract-cn-async fineract-cn-cassandra fineract-cn-data-jpa fineract-cn-command
+
+get_modules_with_fincn_2 fineract-cn-postgresql fineract-cn-test
+# Return to start folder
+cd ..
+
+# REM create tools folder
+mkdir tools
+cd tools
+
+# REM initialize fineract-cn-crypto
+git clone https://github.com/$githubAccount/fineract-cn-crypto.git
+cd fineract-cn-crypto
+git remote add upstream https://github.com/apache/fineract-cn-crypto.git
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# exit tools directory
+cd ..
+get_modules fineract-cn-anubis fineract-cn-permitted-feign-client
+
+get_modules_with_fincn_2 fineract-cn-identity fineract-cn-provisioner fineract-cn-office
+
+# REM clone fineract-cn-rhythm FINCN-115
+git clone https://github.com/ebenezergraham/fineract-cn-rhythm.git -b FINCN-115
+cd fineract-cn-rhythm
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# REM clone fineract-cn-customer FINCN-116
+git clone https://github.com/ebenezergraham/fineract-cn-customer.git -b FINCN-116
+cd fineract-cn-customer
+git remote add upstream https://github.com/apache/fineract-cn-customer.git
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# REM clone fineract-cn-group FINCN-118
+git clone https://github.com/izakey/fineract-cn-group.git -b FINCN-118
+cd fineract-cn-group
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+get_modules_with_fincn_2 fineract-cn-accounting fineract-cn-portfolio
+
+# REM clone fineract-cn-deposit-account-management FINCN-122
+git clone https://github.com/izakey/fineract-cn-deposit-account-management.git -b FINCN-122
+cd fineract-cn-deposit-account-management
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# REM clone fineract-cn-cheques FINCN-125
+git clone https://github.com/izakey/fineract-cn-cheques.git -b FINCN-125
+cd fineract-cn-cheques
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# REM clone fineract-cn-teller FINCN-126
+git clone https://github.com/Izakey/fineract-cn-teller.git -b FINCN-126
+cd fineract-cn-teller
+git remote add upstream https://github.com/Izakey/fineract-cn-teller.git
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# REM clone fineract-cn-payroll FINCN-123
+git clone https://github.com/izakey/fineract-cn-payroll.git -b FINCN-123
+cd fineract-cn-payroll
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+get_modules_with_fincn_2 fineract-cn-template
+
+
+# REM clone fineract-cn-notifications FINCN-127
+git clone https://github.com/ebenezergraham/fineract-cn-notifications.git -b FINCN-127
+cd fineract-cn-notifications
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# REM clone fineract-cn-reporting FINCN-119
+git clone https://github.com/izakey/fineract-cn-reporting.git -b FINCN-119
+cd fineract-cn-reporting
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+mkdir integration-tests
+cd integration-tests
+
+# REM clone fineract-cn-default-setup FINCN-155
+git clone https://github.com/ebenezergraham/fineract-cn-default-setup.git -b FINCN-155
+cd fineract-cn-default-setup
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+
+# REM clone fineract-cn-service-starter FINCN-140
+git clone https://github.com/izakey/fineract-cn-service-starter.git -b FINCN-140
+cd fineract-cn-service-starter
+chmod +x gradlew
+./gradlew publishToMavenLocal
+cd ..
+get_modules_with_fincn_2 fineract-cn-demo-server
+
+cd ..

--- a/src/main/java/org/apache/fineract/cn/dev/ServiceRunner.java
+++ b/src/main/java/org/apache/fineract/cn/dev/ServiceRunner.java
@@ -73,6 +73,7 @@ import org.apache.fineract.cn.rhythm.api.v1.client.RhythmManager;
 import org.apache.fineract.cn.rhythm.api.v1.events.BeatEvent;
 import org.apache.fineract.cn.teller.api.v1.client.TellerManager;
 import org.apache.fineract.cn.test.env.ExtraProperties;
+import org.apache.fineract.cn.test.fixture.postgresql.PostgreSQLInitializer;
 import org.apache.fineract.cn.test.listener.EnableEventRecording;
 import org.apache.fineract.cn.test.listener.EventRecorder;
 import org.apache.fineract.cn.test.servicestarter.ActiveMQForTest;
@@ -111,10 +112,6 @@ public class ServiceRunner {
   private static final String ADMIN_USER_NAME = "antony";
   private static final String TEST_LOGGER = "test-logger";
   private static final String LOAN_INCOME_LEDGER = "1100";
-
-  private static final String NOTIFICATION_USER_PASSWORD = "shingi";
-  private static final String NOTIFICATION_ROLE = "notificationAdmin";
-  private static final String NOTIFICATION_USER_IDENTIFIER = "wadaadmin";
 
   private static Microservice<Provisioner> provisionerService;
   private static Microservice<IdentityManager> identityManager;
@@ -183,6 +180,8 @@ public class ServiceRunner {
   /* Enabling lite mode restricts the working set of micro-services to Provisioner, Identity, Rhythm, Organization and Customer
    */
   private boolean liteModeEnabled;
+  private List<Tenant> tenantsToCreate;
+  private AuthenticationResponse authenticationResponse;
 
 
   public ServiceRunner() {
@@ -190,11 +189,11 @@ public class ServiceRunner {
   }
 
   @Before
-  public void before() throws Exception
-  {
+  public void before() throws Exception {
     this.isPersistent = this.environment.containsProperty("demoserver.persistent");
     this.shouldProvision = this.environment.containsProperty("demoserver.provision");
-    liteModeEnabled = this.environment.containsProperty("demoserver.lite");
+    this.liteModeEnabled = this.environment.containsProperty("demoserver.lite");
+    this.runInDebug = this.environment.containsProperty("demoserver.runInDebug");
 
     if (!this.isPersistent) {
       // start embedded Cassandra
@@ -216,16 +215,21 @@ public class ServiceRunner {
     provisionerService.getProcessEnvironment().setProperty("system.initialclientid", ServiceRunner.CLIENT_ID);
     startService(generalProperties, provisionerService);
 
+    // Creating Tenants before application startup to allow all microservices establish database connection
+    // to the PostgreSQL Database
+    createTenants();
+
     ServiceRunner.identityManager = new Microservice<>(IdentityManager.class, "identity", "0.1.0-BUILD-SNAPSHOT", ServiceRunner.INTEGRATION_TEST_ENVIRONMENT)
-            .addProperties(new ExtraProperties() {{
-              setProperty("identity.token.refresh.secureCookie", "false");}});
+        .addProperties(new ExtraProperties() {{
+          setProperty("identity.token.refresh.secureCookie", "false");
+        }});
     startService(generalProperties, identityManager);
 
     ServiceRunner.rhythmManager = new Microservice<>(RhythmManager.class, "rhythm", "0.1.0-BUILD-SNAPSHOT", ServiceRunner.INTEGRATION_TEST_ENVIRONMENT)
-            .addProperties(new ExtraProperties() {{
-              setProperty("rhythm.beatCheckRate", Long.toString(TimeUnit.MINUTES.toMillis(10)));
-              setProperty("rhythm.user", SCHEDULER_USER_NAME);
-            }});
+        .addProperties(new ExtraProperties() {{
+          setProperty("rhythm.beatCheckRate", Long.toString(TimeUnit.MINUTES.toMillis(10)));
+          setProperty("rhythm.user", SCHEDULER_USER_NAME);
+        }});
     startService(generalProperties, rhythmManager);
 
     ServiceRunner.organizationManager = new Microservice<>(OrganizationManager.class, "office", "0.1.0-BUILD-SNAPSHOT", ServiceRunner.INTEGRATION_TEST_ENVIRONMENT);
@@ -234,14 +238,14 @@ public class ServiceRunner {
     ServiceRunner.customerManager = new Microservice<>(CustomerManager.class, "customer", "0.1.0-BUILD-SNAPSHOT", ServiceRunner.INTEGRATION_TEST_ENVIRONMENT);
     startService(generalProperties, customerManager);
 
-    if(!liteModeEnabled) {
+    if (!liteModeEnabled) {
       ServiceRunner.ledgerManager = new Microservice<>(LedgerManager.class, "accounting", "0.1.0-BUILD-SNAPSHOT", ServiceRunner.INTEGRATION_TEST_ENVIRONMENT);
       startService(generalProperties, ledgerManager);
 
       ServiceRunner.portfolioManager = new Microservice<>(PortfolioManager.class, "portfolio", "0.1.0-BUILD-SNAPSHOT", ServiceRunner.INTEGRATION_TEST_ENVIRONMENT)
-              .addProperties(new ExtraProperties() {{
-                setProperty("portfolio.bookLateFeesAndInterestAsUser", SCHEDULER_USER_NAME);
-              }});
+          .addProperties(new ExtraProperties() {{
+            setProperty("portfolio.bookLateFeesAndInterestAsUser", SCHEDULER_USER_NAME);
+          }});
       startService(generalProperties, portfolioManager);
 
       ServiceRunner.depositAccountManager = new Microservice<>(DepositAccountManager.class, "deposit-account-management", "0.1.0-BUILD-SNAPSHOT", ServiceRunner.INTEGRATION_TEST_ENVIRONMENT);
@@ -269,7 +273,7 @@ public class ServiceRunner {
 
   @After
   public void tearDown() throws Exception {
-    if(!liteModeEnabled) {
+    if (!liteModeEnabled) {
       ServiceRunner.notificationManager.kill();
       ServiceRunner.groupManager.kill();
       ServiceRunner.payrollManager.kill();
@@ -299,15 +303,15 @@ public class ServiceRunner {
       } else {
         this.migrateServices();
       }
-    }
-    finally {
+    } finally {
       ServiceRunner.provisionerService.kill();
     }
 
     System.out.println(identityManager.toString());
     System.out.println(organizationManager.toString());
     System.out.println(customerManager.toString());
-    if(!liteModeEnabled) {
+
+    if (!liteModeEnabled) {
       System.out.println(ledgerManager.toString());
       System.out.println(portfolioManager.toString());
       System.out.println(depositAccountManager.toString());
@@ -365,14 +369,12 @@ public class ServiceRunner {
   }
 
   private void provisionAppsViaSeshat() throws InterruptedException, IOException {
-    final AuthenticationResponse authenticationResponse =
-            ServiceRunner.provisionerService.api().authenticate(ServiceRunner.CLIENT_ID, ApiConstants.SYSTEM_SU, "oS/0IiAME/2unkN1momDrhAdNKOhGykYFH/mJN20");
-
     final List<Application> applicationsToCreate = new ArrayList<>();
     applicationsToCreate.add(ApplicationBuilder.create(ServiceRunner.identityManager.name(), ServiceRunner.identityManager.uri()));
     applicationsToCreate.add(ApplicationBuilder.create(ServiceRunner.rhythmManager.name(), ServiceRunner.rhythmManager.uri()));
     applicationsToCreate.add(ApplicationBuilder.create(ServiceRunner.organizationManager.name(), ServiceRunner.organizationManager.uri()));
     applicationsToCreate.add(ApplicationBuilder.create(ServiceRunner.customerManager.name(), ServiceRunner.customerManager.uri()));
+
     if (!liteModeEnabled) {
       applicationsToCreate.add(ApplicationBuilder.create(ServiceRunner.ledgerManager.name(), ServiceRunner.ledgerManager.uri()));
       applicationsToCreate.add(ApplicationBuilder.create(ServiceRunner.portfolioManager.name(), ServiceRunner.portfolioManager.uri()));
@@ -385,19 +387,10 @@ public class ServiceRunner {
       applicationsToCreate.add(ApplicationBuilder.create(ServiceRunner.notificationManager.name(), ServiceRunner.notificationManager.uri()));
     }
 
-
-    final List<Tenant> tenantsToCreate = Arrays.asList(
-            TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "playground", "A place to mess around and have fun", "playground")
-            //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "demo-cccu", "Demo for CCCU", "demo_cccu"),
-            //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "SKCUKNS1", "St Kitts Cooperative Credit Union", "SKCUKNS1"),
-            //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "PCCUKNS1", "Police Cooperative Credit Union", "PCCUKNS1"),
-            //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "FCCUKNS1", "FND Cooperative Credit Union", "FCCUKNS1"),
-            //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "NCCUKNN1", "Nevis Cooperative Credit Union", "NCCUKNN1")
-    );
-
     try (final AutoSeshat ignored = new AutoSeshat(authenticationResponse.getToken())) {
       applicationsToCreate.forEach(application -> ServiceRunner.provisionerService.api().createApplication(application));
     }
+
     for (final Tenant tenant : tenantsToCreate) {
       try (final AutoSeshat ignored = new AutoSeshat(authenticationResponse.getToken())) {
         provisionAppsViaSeshatForTenant(tenant);
@@ -405,20 +398,36 @@ public class ServiceRunner {
     }
   }
 
+  private void createTenants() {
+    this.authenticationResponse = ServiceRunner.provisionerService.api().authenticate(ServiceRunner.CLIENT_ID, ApiConstants.SYSTEM_SU, "oS/0IiAME/2unkN1momDrhAdNKOhGykYFH/mJN20");
+
+    tenantsToCreate = Arrays.asList(
+        TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "playground", "A place to mess around and have fun", "playground")
+        //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "demo-cccu", "Demo for CCCU", "demo_cccu"),
+        //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "SKCUKNS1", "St Kitts Cooperative Credit Union", "SKCUKNS1"),
+        //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "PCCUKNS1", "Police Cooperative Credit Union", "PCCUKNS1"),
+        //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "FCCUKNS1", "FND Cooperative Credit Union", "FCCUKNS1"),
+        //TenantBuilder.create(ServiceRunner.provisionerService.getProcessEnvironment(), "NCCUKNN1", "Nevis Cooperative Credit Union", "NCCUKNN1")
+    );
+
+    for (final Tenant tenant : tenantsToCreate) {
+      try (final AutoSeshat ignored = new AutoSeshat(authenticationResponse.getToken())) {
+        provisionerService.api().createTenant(tenant);
+      }
+    }
+  }
+
   private String provisionAppsViaSeshatForTenant(final Tenant tenant) throws InterruptedException, IOException {
-    provisionerService.api().createTenant(tenant);
 
     try (final AutoTenantContext ignored = new AutoTenantContext(tenant.getIdentifier())) {
 
       final AssignedApplication isisAssigned = new AssignedApplication();
       isisAssigned.setName(identityManager.name());
 
-      final IdentityManagerInitialization tenantAdminPassword
-              = provisionerService.api().assignIdentityManager(tenant.getIdentifier(), isisAssigned);
+      final IdentityManagerInitialization tenantAdminPassword = provisionerService.api().assignIdentityManager(tenant.getIdentifier(), isisAssigned);
       provisionApp(tenant, rhythmManager, org.apache.fineract.cn.rhythm.api.v1.events.EventConstants.INITIALIZE);
       provisionApp(tenant, ServiceRunner.organizationManager, org.apache.fineract.cn.office.api.v1.EventConstants.INITIALIZE);
       provisionApp(tenant, ServiceRunner.customerManager, CustomerEventConstants.INITIALIZE);
-
 
       final UserWithPassword orgAdminUserPassword = createOrgAdminRoleAndUser(tenantAdminPassword.getAdminPassword());
 
@@ -439,10 +448,10 @@ public class ServiceRunner {
 
         try (final AutoUserContext ignored2 = new AutoUserContext(schedulerUser.getIdentifier(), schedulerUserAuthentication.getAccessToken())) {
           identityManager.api().setApplicationPermissionEnabledForUser(
-                  rhythmManager.name(),
-                  org.apache.fineract.cn.identity.api.v1.PermittableGroupIds.APPLICATION_SELF_MANAGEMENT,
-                  schedulerUser.getIdentifier(),
-                  true);
+              rhythmManager.name(),
+              org.apache.fineract.cn.identity.api.v1.PermittableGroupIds.APPLICATION_SELF_MANAGEMENT,
+              schedulerUser.getIdentifier(),
+              true);
           Assert.assertTrue(this.eventRecorder.wait(EventConstants.OPERATION_PUT_APPLICATION_PERMISSION_USER_ENABLED, new ApplicationPermissionUserEvent(rhythmManager.name(), org.apache.fineract.cn.identity.api.v1.PermittableGroupIds.APPLICATION_SELF_MANAGEMENT, schedulerUser.getIdentifier())));
         }
 
@@ -451,12 +460,12 @@ public class ServiceRunner {
         provisionApp(tenant, portfolioManager, org.apache.fineract.cn.portfolio.api.v1.events.EventConstants.INITIALIZE);
 
         Assert.assertTrue(this.eventRecorder.wait(EventConstants.OPERATION_POST_PERMITTABLE_GROUP,
-                org.apache.fineract.cn.rhythm.spi.v1.PermittableGroupIds.forApplication(portfolioManager.name())));
+            org.apache.fineract.cn.rhythm.spi.v1.PermittableGroupIds.forApplication(portfolioManager.name())));
 
         for (int i = 0; i < 24; i++) {
           Assert.assertTrue("Beat #" + i,
-                  eventRecorder.wait(org.apache.fineract.cn.rhythm.api.v1.events.EventConstants.POST_BEAT,
-                          new BeatEvent(portfolioManager.name(), "alignment" + i)));
+              eventRecorder.wait(org.apache.fineract.cn.rhythm.api.v1.events.EventConstants.POST_BEAT,
+                  new BeatEvent(portfolioManager.name(), "alignment" + i)));
         }
 
         final Authentication schedulerAuthentication;
@@ -467,13 +476,13 @@ public class ServiceRunner {
         try (final AutoUserContext ignored2 = new AutoUserContext(schedulerUser.getIdentifier(), schedulerAuthentication.getAccessToken())) {
           //Allow rhythm to send a beat to portfolio as the scheduler user.
           identityManager.api().setApplicationPermissionEnabledForUser(
-                  rhythmManager.name(),
-                  org.apache.fineract.cn.rhythm.spi.v1.PermittableGroupIds.forApplication(portfolioManager.name()),
-                  schedulerUser.getIdentifier(),
-                  true);
+              rhythmManager.name(),
+              org.apache.fineract.cn.rhythm.spi.v1.PermittableGroupIds.forApplication(portfolioManager.name()),
+              schedulerUser.getIdentifier(),
+              true);
           Assert.assertTrue(this.eventRecorder.wait(EventConstants.OPERATION_PUT_APPLICATION_PERMISSION_USER_ENABLED,
-                  new ApplicationPermissionUserEvent(rhythmManager.name(),
-                          org.apache.fineract.cn.rhythm.spi.v1.PermittableGroupIds.forApplication(portfolioManager.name()), schedulerUser.getIdentifier())));
+              new ApplicationPermissionUserEvent(rhythmManager.name(),
+                  org.apache.fineract.cn.rhythm.spi.v1.PermittableGroupIds.forApplication(portfolioManager.name()), schedulerUser.getIdentifier())));
         }
 
         provisionApp(tenant, depositAccountManager, org.apache.fineract.cn.deposit.api.v1.EventConstants.INITIALIZE);
@@ -489,8 +498,6 @@ public class ServiceRunner {
         provisionApp(tenant, ServiceRunner.groupManager, org.apache.fineract.cn.group.api.v1.EventConstants.INITIALIZE);
 
         provisionApp(tenant, ServiceRunner.notificationManager, org.apache.fineract.cn.notification.api.v1.events.NotificationEventConstants.INITIALIZE);
-
-        createNotificationsAdmin(tenantAdminPassword.getAdminPassword());
 
         createChartOfAccounts(orgAdminUserPassword);
       }
@@ -521,9 +528,9 @@ public class ServiceRunner {
   }
 
   private <T> void provisionApp(
-          final Tenant tenant,
-          final Microservice<T> service,
-          final String initialize_event) throws InterruptedException {
+      final Tenant tenant,
+      final Microservice<T> service,
+      final String initialize_event) throws InterruptedException {
     logger.info("Provisioning service '{}', for tenant '{}'.", service.name(), tenant.getName());
 
     final AssignedApplication assignedApp = new AssignedApplication();
@@ -533,7 +540,7 @@ public class ServiceRunner {
 
     /*Assert.assertTrue(this.eventRecorder.wait(initialize_event, initialize_event));
     Assert.assertTrue(this.eventRecorder.waitForMatch(EventConstants.OPERATION_PUT_APPLICATION_SIGNATURE,
-            (ApplicationSignatureEvent x) -> x.getApplicationIdentifier().equals(service.name())));*/
+        (ApplicationSignatureEvent x) -> x.getApplicationIdentifier().equals(service.name())));*/
   }
 
   private UserWithPassword createSchedulerUserRoleAndPassword(String tenantAdminPassword) throws InterruptedException {
@@ -635,6 +642,10 @@ public class ServiceRunner {
     accountManagementPermission.setAllowedOperations(AllowedOperation.ALL);
     accountManagementPermission.setPermittableEndpointGroupIdentifier(org.apache.fineract.cn.accounting.api.v1.PermittableGroupIds.THOTH_ACCOUNT);
 
+    final Permission customerPermission = new Permission();
+    customerPermission.setAllowedOperations(Collections.singleton(AllowedOperation.READ));
+    customerPermission.setPermittableEndpointGroupIdentifier(org.apache.fineract.cn.customer.PermittableGroupIds.CUSTOMER);
+
     final Role role = new Role();
     role.setIdentifier("orgadmin");
     role.setPermissions(
@@ -645,64 +656,23 @@ public class ServiceRunner {
             roleAllPermission,
             selfManagementPermission,
             ledgerManagementPermission,
-            accountManagementPermission
+            accountManagementPermission,
+            customerPermission
         )
     );
 
-    return role;
-  }
-
-  private UserWithPassword createNotificationsAdmin(final String tenantAdminPassword) throws InterruptedException {
-    final Authentication adminAuthentication;
-    try (final AutoUserContext ignored = new AutoGuest()) {
-      adminAuthentication = ServiceRunner.identityManager.api().login(ADMIN_USER_NAME, tenantAdminPassword);
-    }
-
-    try (final AutoUserContext ignored = new AutoUserContext(ADMIN_USER_NAME, adminAuthentication.getAccessToken())) {
-      final Role notificationRole = defineNotificationRole();
-
-      ServiceRunner.identityManager.api().createRole(notificationRole);
-      Assert.assertTrue(this.eventRecorder.wait(EventConstants.OPERATION_POST_ROLE, notificationRole.getIdentifier()));
-
-      final UserWithPassword notificationUser = new UserWithPassword();
-      notificationUser.setIdentifier(NOTIFICATION_USER_IDENTIFIER);
-      notificationUser.setPassword(Base64Utils.encodeToString(NOTIFICATION_USER_PASSWORD.getBytes()));
-      notificationUser.setRole(notificationRole.getIdentifier());
-
-      ServiceRunner.identityManager.api().createUser(notificationUser);
-      Assert.assertTrue(this.eventRecorder.wait(EventConstants.OPERATION_POST_USER, notificationUser.getIdentifier()));
-
-      ServiceRunner.identityManager.api().logout();
-
-      enableUser(notificationUser);
-      return notificationUser;
-    }
-  }
-
-  private Role defineNotificationRole() {
-    final Permission customerPermission = new Permission();
-    customerPermission.setAllowedOperations(Collections.singleton(AllowedOperation.READ));
-    customerPermission.setPermittableEndpointGroupIdentifier(org.apache.fineract.cn.customer.PermittableGroupIds.CUSTOMER);
-
-    final Role role = new Role();
-    role.setIdentifier(NOTIFICATION_ROLE);
-    role.setPermissions(Arrays.asList(
-        customerPermission
-        )
-    );
     return role;
   }
 
   private void enableUser(final UserWithPassword userWithPassword) throws InterruptedException {
     final Authentication passwordOnlyAuthentication
-            = identityManager.api().login(userWithPassword.getIdentifier(), userWithPassword.getPassword());
+        = identityManager.api().login(userWithPassword.getIdentifier(), userWithPassword.getPassword());
     try (final AutoUserContext ignored
-                 = new AutoUserContext(userWithPassword.getIdentifier(), passwordOnlyAuthentication.getAccessToken()))
-    {
+             = new AutoUserContext(userWithPassword.getIdentifier(), passwordOnlyAuthentication.getAccessToken())) {
       identityManager.api().changeUserPassword(
-              userWithPassword.getIdentifier(), new Password(userWithPassword.getPassword()));
+          userWithPassword.getIdentifier(), new Password(userWithPassword.getPassword()));
       Assert.assertTrue(eventRecorder.wait(EventConstants.OPERATION_PUT_USER_PASSWORD,
-              userWithPassword.getIdentifier()));
+          userWithPassword.getIdentifier()));
     }
   }
 


### PR DESCRIPTION
1. Factored out tenant creation from seshat provision operation. This allows the tenants to be created early so applications can establish database connections to postgresql during startup.
2. Removed dedicated notification User.

